### PR TITLE
Allow arguments through the commands run-ios/run-android

### DIFF
--- a/cavy.js
+++ b/cavy.js
@@ -5,6 +5,12 @@ const { spawn, execFileSync } = require('child_process');
 
 const server = require('./server')
 
+function getCommandParams(command, args) {
+  const commandIndex = args.indexOf(command);
+
+  return args.slice(commandIndex, args.length)
+}
+
 // Borrowed from react-native-cli
 function getAdbPath() {
   return process.env.ANDROID_HOME
@@ -26,7 +32,7 @@ if (reactNativeCommand !== 'run-ios' && reactNativeCommand !== 'run-android') {
 }
 
 console.log(`cavy: running \`react-native ${reactNativeCommand}\`...`);
-let rn = spawn('react-native', [reactNativeCommand], {stdio: 'inherit'});
+let rn = spawn('react-native', [reactNativeCommand, ...getCommandParams(reactNativeCommand, process.argv)], {stdio: 'inherit'});
 rn.on('close', (code) => {
   console.log(`cavy: react-native exited with code ${code}.`);
   if (code) {
@@ -48,7 +54,7 @@ rn.on('close', (code) => {
         process.exit(1);
       }
     }
-      
+
     console.log(`cavy: listening on port 8082 for test results...`);
   });
 });


### PR DESCRIPTION
## Context

This PR allows the cavy-cli to receive react native arguments such as `--simulator`, `--configuration` and so on.