### PR TITLE
Build and test app from optional index.test.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ $ cavy run-ios
 $ cavy run-android
 ```
 
+**cavy-cli** will use an `index.test.js` entry point if you have one in your
+React Native project. This allows you to set up your tests to only run
+when your app is built by **cavy-cli**.
+ 
 ## TODO
 
 - Make this the default way of running Cavy; only run tests if **cavy-cli** is
@@ -72,6 +76,12 @@ $ cavy run-android
 ## Contributing
 
 Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
+
+You can test your local version of cavy-cli by running `npm link` within the
+`cavy-cli` folder. This will make it so `cavy` is pointing to the `cavy.js`
+script in your local copy of `cavy-cli`. See
+[the documentation for npm link](https://docs.npmjs.com/cli/link) for more
+information.
 
 - Check out the latest master to make sure the feature hasn't been implemented
   or the bug hasn't been fixed yet.

--- a/cavy.js
+++ b/cavy.js
@@ -82,17 +82,19 @@ function buildApp() {
   });
 }
 
-// If we intially swapped out the index.js file for the test file, swap it back
-// before exiting the process.
+// Handle reverting any file changes made before exiting the process.
 process.on('exit', () => {
   teardown();
 });
 
+// If the user interrupts the process (ctrl-c), revert any file changes before
+// exiting.
 process.on('SIGINT', () => {
   teardown();
   process.exit(1);
 });
 
+// If file changes have been made, revert them.
 function teardown() {
   if (testEntryPoint) {
     exec(`mv index.js index.test.js && mv index.temp.js index.js`);

--- a/cavy.js
+++ b/cavy.js
@@ -38,8 +38,6 @@ const check = exec(`test -e ./index.test.js`);
 // should be.
 check.on('close', (code) => {
   if (code == 0) {
-    // Set an env var so that the test server knows whether to teardown this
-    // test setup process.
     const setUp = exec(`mv index.js index.temp.js && mv index.test.js index.js`);
     setUp.on('close', () => {
       testEntryPoint = true;

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const server = express();
 const chalk = require('chalk');
-const { exec } = require('child_process');
 
 server.use(express.json());
 
@@ -13,13 +12,6 @@ function countString(count, str) {
   let string = (count == 1) ? str : str + 's';
   return `${count} ${string}`;
 };
-
-// If we intially swapped out the index.js file for the test file, swap it back.
-function cleanUpTestFiles() {
-  if (process.env.TEST_ENTRY_POINT_PRESENT == 'true') {
-    exec(`mv index.js index.test.js && mv index.temp.js index.js`);
-  }
-}
 
 // Public: POST route which accepts json report object, console logs the results
 // and quits the process with either exit code 1 or 0 depending on whether any
@@ -47,12 +39,10 @@ server.post('/report', (req, res) => {
   // If all tests pass, exit with code 0, else code 1
   if (!errorCount) {
     console.log(chalk.green(endMsg));
-    cleanUpTestFiles();
     res.send('ok');
     process.exit(0);
   } else {
     console.log(chalk.red(endMsg));
-    cleanUpTestFiles();
     res.send('failed');
     process.exit(1);
   }


### PR DESCRIPTION
**Functionality**
- If `cavy-cli` detects that an app has an `index.test.js` file, then it uses this file to build and test the app. It assumes that this is the entry point containing the Cavy configuration.
- If there is no `index.test.js` file present, then it functions as before.

**Points to note**
- This doesn't yet support (but could easily) apps with separate entry points for ios and android. We could suggest two test files in this case i.e. `index.ios.test.js` and `index.android.test.js`.

**To test**
- You can test it out using the sample Cavy app in the [Cavy repo](https://github.com/pixielabs/cavy).
- Copy contents of `index.js` to new `index.test.js`
- Remove Cavy from `index.js` i.e.

```
import {AppRegistry} from 'react-native';
import {name as appName} from './app.json';
import EmployeeDirectoryApp from './app/EmployeeDirectoryApp';
AppRegistry.registerComponent(appName, () => EmployeeDirectoryApp);
```