### PR TITLE
New command - cavy init

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ command line. When the tests finish the command outputs the results and quits
 with the relevant exit code (0 for success, 1 for failure) which can be used by
 continuous integration scripts to determine if the test suite passed or not.
 
-**cavy-cli is in an early stage of development**. But we are using it to test
-Cavy itself! Check out [our sample app Circle CI
-configuration](https://github.com/pixielabs/cavy/blob/master/.circleci/config.yml) 
+We use cavy-cli to test Cavy itself! Check out [our sample app Circle CI
+configuration](https://github.com/pixielabs/cavy/blob/master/.circleci/config.yml)
 for inspiration.
 
 ## Installation
@@ -34,18 +33,19 @@ or `yarn`:
 $ yarn global add cavy-cli
 ```
 
-Set the `sendReport` prop to `true` on your Cavy `<Tester>` component in your
-app:
+## Commands
 
-```jsx
-<Tester specs={...} store={...} sendReport={true}>
-...
-</Tester>
+```shell
+$ cavy init [specFolderName]
 ```
 
-## Basic usage
+Run `cavy init` inside your React Native project to set up testing with Cavy.
+Gives you an example spec and an `index.test.js` file from which Cavy will boot
+your app and run your specs. See [App entry point](#app-entry-point) below for
+how to tweak this file to suit your app.
 
-From within your React Native project, with Cavy already installed and set up
+`specFolderName` (optional) - the directory in which you'd like to keep your
+spec files. Defaults to `specs`.
 
 ```shell
 # To test on iOS
@@ -54,12 +54,24 @@ $ cavy run-ios
 # To test on Android
 $ cavy run-android
 ```
+Once you have Cavy and your tests set up, run either `cavy run-ios` or
+`cavy run-android` from within your project to run tests. Under the hood,
+**cavy-cli** calls react-native-cli commands. This means you can optionally pass
+in any react-native-cli options that are valid for either `react-native run-ios`
+or `react-native run-android`.
+
+## App entry point
 
 **cavy-cli** will use an `index.test.js` entry point if you have one in your
-React Native project. This allows you to set up your tests to only run
-when your app is built by **cavy-cli**.
+React Native project (running `cavy init` will automatically generate one for
+you).
 
-For example:
+This way tests will run when and only when your app is booted by **cavy-cli**.
+
+**Make sure the `sendReport` prop is set to `true` on your Cavy `<Tester>`
+component. cavy-cli will not receive test results otherwise.**
+
+Example set up:
 
 ```js
 // index.js
@@ -104,7 +116,6 @@ AppRegistry.registerComponent('AppName', () => AppWrapper);
 - Get a working example of an Android build in CI. We couldn't get an Android
   emulator running properly in Circle CI. If you have an example of
   **cavy-cli** working in CI for Android builds, please get in touch!
-- Pass through arguments to react-native command.
 
 ## Contributing
 

--- a/cavy.js
+++ b/cavy.js
@@ -20,8 +20,16 @@ if (!['run-ios', 'run-android', 'init'].includes(command)) {
   process.exit(1);
 }
 
+const args = getCommandParams(command, process.argv);
+
 if (command == 'init') {
-  init();
+  init(args);
 } else {
-  runTests(process, command);
+  runTests(command, args);
+}
+
+function getCommandParams(command, args) {
+  const commandIndex = args.indexOf(command);
+
+  return args.slice(commandIndex, args.length);
 }

--- a/cavy.js
+++ b/cavy.js
@@ -3,33 +3,39 @@ const program = require('commander');
 const init = require('./src/init');
 const runTests = require('./src/runTests');
 
-function _getCommandParams(command, args) {
+function getCommandParams(command, args) {
   const commandIndex = args.indexOf(command);
-
   return args.slice(commandIndex, args.length);
 }
 
 // Stop quitting unless we want to
 process.stdin.resume();
 
-let command;
+program
+  .command('init [specFolderName]')
+  .description('Add cavy to a project with optional spec folder name')
+  .action(specFolderName => {
+    init(specFolderName);
+  });
 
-program.
-  version('0.0.3').
-  arguments('<run-ios|run-android|init>', 'react-native command to run').
-  action((cmd) => command = cmd).
-  parse(process.argv);
+program
+  .command('run-ios')
+  .description('Run cavy spec on an ios simulator or device')
+  .allowUnknownOption()
+  .action(cmd => {
+    const command = cmd.name();
+    const args = getCommandParams(command, process.argv);
+    runTests(command, args);
+  });
 
-// Check that the user has entered a valid argument
-if (!['run-ios', 'run-android', 'init'].includes(command)) {
-  program.outputHelp();
-  process.exit(1);
-}
+program
+  .command('run-android')
+  .description('Run cavy spec on an android simulator or device')
+  .allowUnknownOption()
+  .action(cmd => {
+    const command = cmd.name();
+    const args = getCommandParams(command, process.argv);
+    runTests(command, args);
+  });
 
-const args = _getCommandParams(command, process.argv);
-
-if (command == 'init') {
-  init(args);
-} else {
-  runTests(command, args);
-}
+program.parse(process.argv);

--- a/cavy.js
+++ b/cavy.js
@@ -1,104 +1,27 @@
 #!/usr/bin/env node
 const program = require('commander');
-const { spawn, execFileSync, execSync } = require('child_process');
-const { existsSync } = require('fs');
-
-const server = require('./server')
+const init = require('./src/init');
+const runTests = require('./src/runTests');
 
 // Stop quitting unless we want to
 process.stdin.resume();
 
-let testEntryPoint = false;
-
-function getCommandParams(command, args) {
-  const commandIndex = args.indexOf(command);
-
-  return args.slice(commandIndex, args.length)
-}
-
-// Borrowed from react-native-cli
-function getAdbPath() {
-  return process.env.ANDROID_HOME
-    ? process.env.ANDROID_HOME + '/platform-tools/adb'
-    : 'adb';
-}
-
-// If file changes have been made, revert them.
-function teardown() {
-  if (testEntryPoint) {
-    console.log('cavy: putting your index.js back');
-    const cmd = 'mv index.js index.test.js && mv index.notest.js index.js';
-    console.log(`cavy: running \`${cmd}\`...`);
-    execSync(cmd);
-  }
-}
-
-let reactNativeCommand;
+let command;
 
 program.
   version('0.0.3').
-  arguments('<run-ios|run-android>', 'react-native command to run').
-  action((cmd) => reactNativeCommand = cmd).
+  arguments('<run-ios|run-android|init>', 'react-native command to run').
+  action((cmd) => command = cmd).
   parse(process.argv);
 
 // Check that the user has entered a valid argument
-if (reactNativeCommand !== 'run-ios' && reactNativeCommand !== 'run-android') {
+if (!['run-ios', 'run-android', 'init'].includes(command)) {
   program.outputHelp();
   process.exit(1);
 }
 
-// Check whether the app has an index.test.js file...
-if (existsSync('index.test.js')) {
-  // ... and if it does, use it to build the app - this is where Cavy config
-  // should be.
-  console.log('cavy: found an index.test.js entry point. Temporarily replacing index.js to run tests');
-
-  const cmd = 'mv index.js index.notest.js && mv index.test.js index.js';
-  console.log(`cavy: running \`${cmd}\`...`);
-  execSync(cmd);
-
-  // Save that we did this, so we can undo it later.
-  testEntryPoint = true;
+if (command == 'init') {
+  init();
+} else {
+  runTests(process, command);
 }
-
-// Handle reverting any file changes made before exiting the process.
-process.on('exit', () => {
-  teardown();
-});
-
-// If the user interrupts the process (ctrl-c), revert any file changes before
-// exiting.
-process.on('SIGINT', () => {
-  console.log('cavy: Received SIGINT, cleaning up');
-  process.exit(1);
-});
-
-// Build the app, start the test server and wait for results.
-console.log(`cavy: running \`react-native ${reactNativeCommand}\`...`);
-
-let rn = spawn('react-native', [reactNativeCommand, ...getCommandParams(reactNativeCommand, process.argv)], {stdio: 'inherit'});
-// Wait for the app to build first...
-rn.on('close', (code) => {
-  console.log(`cavy: react-native exited with code ${code}.`);
-  // ... quit if something went wrong.
-  if (code) {
-    return process.exit(code);
-  }
-  // ... start test server, listening for test results to be posted.
-  const app = server.listen(8082, () => {
-    if (reactNativeCommand == 'run-android') {
-      try {
-        // Run ADB reverse tcp:8082 tcp:8082 to allow reporting of test results
-        // from React Native. Borrowed from react-native-cli.
-        const adbPath = getAdbPath();
-        const adbArgs = ['reverse', 'tcp:8082', 'tcp:8082'];
-        console.log(`cavy: Running ${adbPath} ${adbArgs.join(' ')}`);
-        execFileSync(adbPath, adbArgs, {stdio: 'inherit'});
-      } catch(e) {
-        console.error(`Could not run adb reverse: ${e.message}`);
-        process.exit(1);
-      }
-    }
-    console.log(`cavy: listening on port 8082 for test results...`);
-  });
-});

--- a/cavy.js
+++ b/cavy.js
@@ -3,6 +3,12 @@ const program = require('commander');
 const init = require('./src/init');
 const runTests = require('./src/runTests');
 
+function _getCommandParams(command, args) {
+  const commandIndex = args.indexOf(command);
+
+  return args.slice(commandIndex, args.length);
+}
+
 // Stop quitting unless we want to
 process.stdin.resume();
 
@@ -20,16 +26,10 @@ if (!['run-ios', 'run-android', 'init'].includes(command)) {
   process.exit(1);
 }
 
-const args = getCommandParams(command, process.argv);
+const args = _getCommandParams(command, process.argv);
 
 if (command == 'init') {
   init(args);
 } else {
   runTests(command, args);
-}
-
-function getCommandParams(command, args) {
-  const commandIndex = args.indexOf(command);
-
-  return args.slice(commandIndex, args.length);
 }

--- a/src/init.js
+++ b/src/init.js
@@ -1,9 +1,17 @@
-const { existsSync } = require('fs');
+const indexContent = require('../templates/index.test.js');
+const specContent = require('../templates/exampleSpec.js');
+const { existsSync, writeFileSync, mkdirSync } = require('fs');
 
 // This is called if the user types `cavy init`
 function init() {
   if (existsSync('index.js')) {
-    console.log('HELLO');
+    console.log('Adding Cavy to your project...');
+    // Create an index.test.js file in the route of the project
+    writeFileSync('index.test.js', indexContent);
+    // Create a exampleTest.js file in a spec folder in the route of the project.
+    mkdirSync('./specs');
+    writeFileSync('./specs/exampleSpec.js', specContent);
+    // Exit
     process.exit(1);
   }
 }

--- a/src/init.js
+++ b/src/init.js
@@ -1,0 +1,11 @@
+const { existsSync } = require('fs');
+
+// This is called if the user types `cavy init`
+function init() {
+  if (existsSync('index.js')) {
+    console.log('HELLO');
+    process.exit(1);
+  }
+}
+
+module.exports = init;

--- a/src/init.js
+++ b/src/init.js
@@ -5,11 +5,11 @@ const indexContent = require('../templates/index.test.js');
 const specContent = require('../templates/exampleSpec.js');
 const { existsSync, writeFileSync, mkdirSync } = require('fs');
 
+REACT_NATIVE_PATH = 'node_modules/react-native'
 DEFAULT_TEST_DIR = 'specs';
 DEFAULT_ENTRY_FILE = 'index.test.js';
 
-// Sets up Cavy entry index file and example spec.
-function init(args) {
+function setUpCavy(args) {
   console.log('cavy: Adding Cavy to your project...');
 
   // The first additional argument to cavy init is the name of the test
@@ -39,5 +39,16 @@ function init(args) {
   console.log('cavy: Done!');
   process.exit(1);
 }
+
+// Sets up Cavy entry index file and example spec.
+function init(args) {
+  // Check first that you're inside a React Native project.
+  if (existsSync(REACT_NATIVE_PATH)) {
+    setUpCavy(args);
+  } else {
+    console.log(`cavy: Make sure you're inside a React Native project and that you've run npm install.`);
+    process.exit(0)
+  }
+};
 
 module.exports = init;

--- a/src/init.js
+++ b/src/init.js
@@ -3,15 +3,25 @@ const specContent = require('../templates/exampleSpec.js');
 const { existsSync, writeFileSync, mkdirSync } = require('fs');
 
 // This is called if the user types `cavy init`
-function init() {
+function init(args) {
   if (existsSync('index.js')) {
     console.log('Adding Cavy to your project...');
-    // Create an index.test.js file in the route of the project
-    writeFileSync('index.test.js', indexContent);
-    // Create a exampleTest.js file in a spec folder in the route of the project.
-    mkdirSync('./specs');
-    writeFileSync('./specs/exampleSpec.js', specContent);
+
+    // The first additional argument to cavy init is taken to be the name
+    // of the test folder. If nothing is provided, then fall back on `specs`.
+    // This is used in the index.test.js file too.
+    const folderName = args[1] || 'specs';
+
+    // Create an index.test.js file in the route of the project.
+    writeFileSync('index.test.js', indexContent(folderName));
+
+    // Create a exampleTest.js file in the specified folder in the route of the
+    // project.
+    mkdirSync(`./${folderName}`);
+    writeFileSync(`./${folderName}/exampleSpec.js`, specContent);
+
     // Exit
+    console.log('Done!');
     process.exit(1);
   }
 }

--- a/src/init.js
+++ b/src/init.js
@@ -1,8 +1,11 @@
+// Command to set up Cavy within a repo
+// `cavy init`
+//
 const indexContent = require('../templates/index.test.js');
 const specContent = require('../templates/exampleSpec.js');
 const { existsSync, writeFileSync, mkdirSync } = require('fs');
 
-// This is called if the user types `cavy init`
+// Sets up Cavy entry index file and example spec.
 function init(args) {
   if (existsSync('index.js')) {
     console.log('Adding Cavy to your project...');
@@ -12,13 +15,13 @@ function init(args) {
     // This is used in the index.test.js file too.
     const folderName = args[1] || 'specs';
 
-    // Create an index.test.js file in the route of the project.
-    writeFileSync('index.test.js', indexContent(folderName));
-
     // Create a exampleTest.js file in the specified folder in the route of the
     // project.
     mkdirSync(`./${folderName}`);
     writeFileSync(`./${folderName}/exampleSpec.js`, specContent);
+
+    // Create an index.test.js file in the route of the project.
+    writeFileSync('index.test.js', indexContent(folderName));
 
     // Exit
     console.log('Done!');

--- a/src/init.js
+++ b/src/init.js
@@ -17,12 +17,13 @@ function sanitiseFolderName(name) {
 }
 
 // Sets up Cavy entry index file and example spec.
-function setUpCavy(args) {
+function setUpCavy(specFolderName) {
   console.log('cavy: Adding Cavy to your project...');
 
   // The first additional argument to cavy init is the name of the test
   // directory. This is used in the index.test.js file too.
-  const folderName = sanitiseFolderName(args[1]) || DEFAULT_TEST_DIR;
+  let folderName = specFolderName || DEFAULT_TEST_DIR;
+  folderName = sanitiseFolderName(folderName);
 
   if (existsSync(folderName)) {
     console.log(`cavy: Looks like a ./${folderName} directory already exists for this project.`);
@@ -49,9 +50,10 @@ function setUpCavy(args) {
 }
 
 // Checks that you're inside a React Native project, and if so runs setUpCavy.
-function init(args) {
+function init(specFolderName) {
+  console.log(specFolderName);
   if (existsSync(REACT_NATIVE_PATH)) {
-    setUpCavy(args);
+    setUpCavy(specFolderName);
   } else {
     console.log("cavy: Make sure you're inside a React Native project and that you've run npm install.");
     process.exit(0)

--- a/src/init.js
+++ b/src/init.js
@@ -6,6 +6,7 @@ const specContent = require('../templates/exampleSpec.js');
 const { existsSync, writeFileSync, mkdirSync } = require('fs');
 
 DEFAULT_TEST_DIR = 'specs';
+DEFAULT_ENTRY_FILE = 'index.test.js';
 
 // Sets up Cavy entry index file and example spec.
 function init(args) {
@@ -26,11 +27,16 @@ function init(args) {
   mkdirSync(`./${folderName}`);
   writeFileSync(`./${folderName}/exampleSpec.js`, specContent);
 
-  // Create an index.test.js file in the route of the project.
-  writeFileSync('index.test.js', indexContent(folderName));
+  // Don't overwrite any index.test.js file that already exists.
+  if (DEFAULT_ENTRY_FILE) {
+    console.log(`cavy: ${DEFAULT_ENTRY_FILE} already exists, skipping this step.`);
+  } else {
+    // Create an index.test.js file in the route of the project.
+    writeFileSync(DEFAULT_ENTRY_FILE, indexContent(folderName));
+  }
 
   // Exit
-  console.log('Done!');
+  console.log('cavy: Done!');
   process.exit(1);
 }
 

--- a/src/init.js
+++ b/src/init.js
@@ -28,7 +28,7 @@ function init(args) {
   writeFileSync(`./${folderName}/exampleSpec.js`, specContent);
 
   // Don't overwrite any index.test.js file that already exists.
-  if (DEFAULT_ENTRY_FILE) {
+  if (existsSync(DEFAULT_ENTRY_FILE)) {
     console.log(`cavy: ${DEFAULT_ENTRY_FILE} already exists, skipping this step.`);
   } else {
     // Create an index.test.js file in the route of the project.

--- a/src/init.js
+++ b/src/init.js
@@ -11,9 +11,9 @@ DEFAULT_ENTRY_FILE = 'index.test.js';
 
 // Takes a string a strips out any reserved characters for filenames on
 // Unix-like systems or Windows.
-function sanitiseFolderName(name) {
+function folderNameInvalid(name) {
   const regex = /[<>:"\/\\|?*]/g;
-  return name.replace(regex, '')
+  return regex.test(name);
 }
 
 // Sets up Cavy entry index file and example spec.
@@ -23,12 +23,18 @@ function setUpCavy(specFolderName) {
   // The first additional argument to cavy init is the name of the test
   // directory. This is used in the index.test.js file too.
   let folderName = specFolderName || DEFAULT_TEST_DIR;
-  folderName = sanitiseFolderName(folderName);
 
+  // Exit if folder name invalid.
+  if (folderNameInvalid(folderName)) {
+    console.log("cavy: Folder name invalid. Please remove any reserved characters: <>:\"\/\\|?*");
+    process.exit(0);
+  }
+
+  // Exit if spec folder already exists.
   if (existsSync(folderName)) {
     console.log(`cavy: Looks like a ./${folderName} directory already exists for this project.`);
     console.log('cavy: To continue set up, re-run the command with an alternative test directory name: `cavy init <test-directory>`')
-    process.exit(0)
+    process.exit(0);
   }
 
   // Create a exampleTest.js file in the specified folder in the route of the
@@ -51,7 +57,6 @@ function setUpCavy(specFolderName) {
 
 // Checks that you're inside a React Native project, and if so runs setUpCavy.
 function init(specFolderName) {
-  console.log(specFolderName);
   if (existsSync(REACT_NATIVE_PATH)) {
     setUpCavy(specFolderName);
   } else {

--- a/src/init.js
+++ b/src/init.js
@@ -5,28 +5,33 @@ const indexContent = require('../templates/index.test.js');
 const specContent = require('../templates/exampleSpec.js');
 const { existsSync, writeFileSync, mkdirSync } = require('fs');
 
+DEFAULT_TEST_DIR = 'specs';
+
 // Sets up Cavy entry index file and example spec.
 function init(args) {
-  if (existsSync('index.js')) {
-    console.log('Adding Cavy to your project...');
+  console.log('cavy: Adding Cavy to your project...');
 
-    // The first additional argument to cavy init is taken to be the name
-    // of the test folder. If nothing is provided, then fall back on `specs`.
-    // This is used in the index.test.js file too.
-    const folderName = args[1] || 'specs';
+  // The first additional argument to cavy init is the name of the test
+  // directory. This is used in the index.test.js file too.
+  const folderName = args[1] || DEFAULT_TEST_DIR;
 
-    // Create a exampleTest.js file in the specified folder in the route of the
-    // project.
-    mkdirSync(`./${folderName}`);
-    writeFileSync(`./${folderName}/exampleSpec.js`, specContent);
-
-    // Create an index.test.js file in the route of the project.
-    writeFileSync('index.test.js', indexContent(folderName));
-
-    // Exit
-    console.log('Done!');
-    process.exit(1);
+  if (existsSync(folderName)) {
+    console.log(`cavy: Looks like a ./${folderName} directory already exists for this project.`);
+    console.log('cavy: To continue set up, re-run the command with an alternative test directory name: `cavy init <test-directory>`')
+    process.exit(0)
   }
+
+  // Create a exampleTest.js file in the specified folder in the route of the
+  // project.
+  mkdirSync(`./${folderName}`);
+  writeFileSync(`./${folderName}/exampleSpec.js`, specContent);
+
+  // Create an index.test.js file in the route of the project.
+  writeFileSync('index.test.js', indexContent(folderName));
+
+  // Exit
+  console.log('Done!');
+  process.exit(1);
 }
 
 module.exports = init;

--- a/src/init.js
+++ b/src/init.js
@@ -9,12 +9,20 @@ REACT_NATIVE_PATH = 'node_modules/react-native'
 DEFAULT_TEST_DIR = 'specs';
 DEFAULT_ENTRY_FILE = 'index.test.js';
 
+// Takes a string a strips out any reserved characters for filenames on
+// Unix-like systems or Windows.
+function sanitiseFolderName(name) {
+  const regex = /[<>:"\/\\|?*]/g;
+  return name.replace(regex, '')
+}
+
+// Sets up Cavy entry index file and example spec.
 function setUpCavy(args) {
   console.log('cavy: Adding Cavy to your project...');
 
   // The first additional argument to cavy init is the name of the test
   // directory. This is used in the index.test.js file too.
-  const folderName = args[1] || DEFAULT_TEST_DIR;
+  const folderName = sanitiseFolderName(args[1]) || DEFAULT_TEST_DIR;
 
   if (existsSync(folderName)) {
     console.log(`cavy: Looks like a ./${folderName} directory already exists for this project.`);
@@ -40,13 +48,12 @@ function setUpCavy(args) {
   process.exit(1);
 }
 
-// Sets up Cavy entry index file and example spec.
+// Checks that you're inside a React Native project, and if so runs setUpCavy.
 function init(args) {
-  // Check first that you're inside a React Native project.
   if (existsSync(REACT_NATIVE_PATH)) {
     setUpCavy(args);
   } else {
-    console.log(`cavy: Make sure you're inside a React Native project and that you've run npm install.`);
+    console.log("cavy: Make sure you're inside a React Native project and that you've run npm install.");
     process.exit(0)
   }
 };

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -1,3 +1,6 @@
+// Command to run iOS or Android tests
+// `cavy run-ios` or `cavy run-android`
+//
 const server = require('../server');
 const { existsSync } = require('fs');
 const { spawn, execFileSync, execSync } = require('child_process');
@@ -17,8 +20,9 @@ function _getAdbPath() {
     : 'adb';
 }
 
-// This is called if the user types `cavy run-ios` or `cavy run-android`. The
-// command argument is one of `run-ios` or `run-android`.
+// Runs tests using the React Native CLI.
+// command: `cavy run-ios` or `cavy run-android`
+// args: any extra arguments the user would usually to pass to `react native run...`
 function runTests(command, args) {
   let testEntryPoint = false;
   // Check whether the app has an index.test.js file...

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -1,0 +1,89 @@
+const server = require('../server');
+const { existsSync } = require('fs');
+const { spawn, execFileSync, execSync } = require('child_process');
+
+function getCommandParams(command, args) {
+  const commandIndex = args.indexOf(command);
+
+  return args.slice(commandIndex, args.length)
+}
+
+// If file changes have been made, revert them.
+function teardown() {
+  if (testEntryPoint) {
+    console.log('cavy: putting your index.js back');
+    const cmd = 'mv index.js index.test.js && mv index.notest.js index.js';
+    console.log(`cavy: running \`${cmd}\`...`);
+    execSync(cmd);
+  }
+}
+
+// Borrowed from react-native-cli
+function getAdbPath() {
+  return process.env.ANDROID_HOME
+    ? process.env.ANDROID_HOME + '/platform-tools/adb'
+    : 'adb';
+}
+
+// This is called if the user types `cavy run-ios` or `cavy run-android`. The
+// command argument is one of `run-ios` or `run-android`.
+function runTests(process, command) {
+  let testEntryPoint = false;
+  // Check whether the app has an index.test.js file...
+  if (existsSync('index.test.js')) {
+    // ... and if it does, use it to build the app - this is where Cavy config
+    // should be.
+    console.log('cavy: found an index.test.js entry point. Temporarily replacing index.js to run tests');
+
+    const cmd = 'mv index.js index.notest.js && mv index.test.js index.js';
+    console.log(`cavy: running \`${cmd}\`...`);
+    execSync(cmd);
+
+    // Save that we did this, so we can undo it later.
+    testEntryPoint = true;
+  }
+
+  // Handle reverting any file changes made before exiting the process.
+  process.on('exit', () => {
+    teardown();
+  });
+
+  // If the user interrupts the process (ctrl-c), revert any file changes before
+  // exiting.
+  process.on('SIGINT', () => {
+    console.log('cavy: Received SIGINT, cleaning up');
+    process.exit(1);
+  });
+
+  // Build the app, start the test server and wait for results.
+  console.log(`cavy: running \`react-native ${command}\`...`);
+
+  let rn = spawn('react-native', [command, ...getCommandParams(command, process.argv)], {stdio: 'inherit'});
+  // Wait for the app to build first...
+  rn.on('close', (code) => {
+    console.log(`cavy: react-native exited with code ${code}.`);
+    // ... quit if something went wrong.
+    if (code) {
+      return process.exit(code);
+    }
+    // ... start test server, listening for test results to be posted.
+    const app = server.listen(8082, () => {
+      if (command == 'run-android') {
+        try {
+          // Run ADB reverse tcp:8082 tcp:8082 to allow reporting of test results
+          // from React Native. Borrowed from react-native-cli.
+          const adbPath = getAdbPath();
+          const adbArgs = ['reverse', 'tcp:8082', 'tcp:8082'];
+          console.log(`cavy: Running ${adbPath} ${adbArgs.join(' ')}`);
+          execFileSync(adbPath, adbArgs, {stdio: 'inherit'});
+        } catch(e) {
+          console.error(`Could not run adb reverse: ${e.message}`);
+          process.exit(1);
+        }
+      }
+      console.log(`cavy: listening on port 8082 for test results...`);
+    });
+  });
+}
+
+module.exports = runTests;

--- a/templates/exampleSpec.js
+++ b/templates/exampleSpec.js
@@ -6,6 +6,7 @@ const content = `export default function(spec) {
       await spec.exists('LoginScreen');
       await spec.fillIn('LoginScreen.EmailInput', 'cavy@example.com');
       await spec.fillIn('LoginScreen.PasswordInput', 'password');
+      await spec.press('LoginScreen.Button');
       await spec.exists('WelcomeScreen');
     });
   });

--- a/templates/exampleSpec.js
+++ b/templates/exampleSpec.js
@@ -1,0 +1,14 @@
+const content = `export default function(spec) {
+
+  spec.describe('Logging in', function() {
+
+    spec.it('filters the list by search input', async function() {
+      await spec.exists('LoginScreen');
+      await spec.fillIn('LoginScreen.EmailInput', 'cavy@example.com');
+      await spec.fillIn('LoginScreen.PasswordInput', 'password');
+      await spec.exists('WelcomeScreen');
+    });
+  });
+}`;
+
+module.exports = content;

--- a/templates/index.test.js
+++ b/templates/index.test.js
@@ -1,0 +1,20 @@
+const content = `import React, { Component } from 'react';
+import { AppRegistry } from 'react-native';
+import { Tester, TestHookStore } from 'cavy';
+import ExampleSpec from './specs/exampleSpec';
+
+const testHookStore = new TestHookStore();
+
+class AppWrapper extends Component {
+  render() {
+    return (
+      <Tester specs={[ExampleSpec]} store={testHookStore} sendReport={true}>
+        // Your app goes here
+      </Tester>
+    );
+  }
+}
+
+AppRegistry.registerComponent('youAppName', () => AppWrapper);`;
+
+module.exports = content;

--- a/templates/index.test.js
+++ b/templates/index.test.js
@@ -1,7 +1,10 @@
-const content = `import React, { Component } from 'react';
+function content(folderName) {
+  return (
+
+`import React, { Component } from 'react';
 import { AppRegistry } from 'react-native';
 import { Tester, TestHookStore } from 'cavy';
-import ExampleSpec from './specs/exampleSpec';
+import ExampleSpec from './${folderName}/exampleSpec';
 
 const testHookStore = new TestHookStore();
 
@@ -15,6 +18,8 @@ class AppWrapper extends Component {
   }
 }
 
-AppRegistry.registerComponent('youAppName', () => AppWrapper);`;
+AppRegistry.registerComponent('youAppName', () => AppWrapper);`
 
+  )
+}
 module.exports = content;

--- a/templates/index.test.js
+++ b/templates/index.test.js
@@ -18,7 +18,7 @@ class AppWrapper extends Component {
   }
 }
 
-AppRegistry.registerComponent('youAppName', () => AppWrapper);`
+AppRegistry.registerComponent('yourAppName', () => AppWrapper);`
 
   )
 }


### PR DESCRIPTION
**Includes**
- A new command `cavy init` that creates an example `index.test.js` file and `exampleSpec.js` in a specs folder.
  - The command takes an additional extra argument for the name of the spec folder, just in case users have other tests that they keep in a `specs` folder. Fall back on `specs` if no argument is given.
- Templates for these example files
- Pulling out all test runner code into a separate file for readability now we have more commands

**To think about**
- If someone already has an `index.test.js` file then at the moment I'm just ignoring that set up step (no overwrite). Happy to hear other people's opinions on what could happen.
- Could get rid of the argument for spec directory thing and instead step people through extra set up steps if conflicts arise ('Enter a directory name..'). This is a good first pass though.

**To do**
- [x] Add instructions to the README once we're happy with functionality

**To test**
- `npm link` this branch to test out locally in the Cavy Directory sample app