### PR TITLE
Add GET / route

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ you).
 
 This way tests will run when and only when your app is booted by **cavy-cli**.
 
-**Make sure the `sendReport` prop is set to `true` on your Cavy `<Tester>`
-component. cavy-cli will not receive test results otherwise.**
-
 Example set up:
 
 ```js
@@ -94,7 +91,7 @@ const testHookStore = new TestHookStore();
 class AppWrapper extends Component {
   render() {
     return (
-      <Tester specs={[AppSpec]} store={testHookStore} sendReport={true}>
+      <Tester specs={[AppSpec]} store={testHookStore}>
         <App />
       </Tester>
     );

--- a/server.js
+++ b/server.js
@@ -48,4 +48,10 @@ server.post('/report', (req, res) => {
   }
 });
 
+// Public: GET route that can be used to check whether the server is listening
+// without have to hit /report.
+server.get('/', (req, res) => {
+  res.send('cavy-cli running');
+});
+
 module.exports = server;


### PR DESCRIPTION
Add simple `GET /` route that cavy can use to check whether the server is listening.