### PR TITLE
Command option -f <file> for custom app entry file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ spec files. Defaults to `specs`.
 
 ```shell
 # To test on iOS
-$ cavy run-ios
+$ cavy run-ios [options]
 
 # To test on Android
-$ cavy run-android
+$ cavy run-android [options]
 ```
 Once you have Cavy and your tests set up, run either `cavy run-ios` or
 `cavy run-android` from within your project to run tests. Under the hood,
@@ -100,6 +100,23 @@ class AppWrapper extends Component {
 
 AppRegistry.registerComponent('AppName', () => AppWrapper);
 ```
+
+## Specifying a custom app entry point
+
+If your app uses an entry point other than `index.js`, run cavy test commands
+with the `--file` flag, followed by the filename as a string. For example:
+
+```shell
+$ cavy run-ios --file index.ios.js
+```
+
+You must also have a corresponding test entry point which includes Cavy. This
+file should be named the same as your entry point, but suffixed with `.test.js`.
+For example, if your app entry point is `index.ios.js`, your test entry point
+should be called `index.ios.test.js`.
+
+If you're using any extra react-native-cli options, include these after the
+cavy-cli `--file` flag.
 
 ## TODO
 

--- a/cavy.js
+++ b/cavy.js
@@ -4,17 +4,15 @@ const init = require('./src/init');
 const runTests = require('./src/runTests');
 
 function getCommandArgs(cmd) {
-  // Get array of Cavy options (short and long).
-  const options = cmd.options.map(option => [option.short, option.long]);
   // Get array of all command line args.
   const allArgs = process.argv;
   const commandIndex = allArgs.indexOf(cmd.name());
   const args = allArgs.slice(commandIndex, allArgs.length)
 
   // Remove Cavy options from other args so RN cli doesn't try to call them.
-  options.forEach(option => {
+  cmd.options.forEach(option => {
     for (var i = 0; i < args.length; i++) {
-      if (option.includes(args[i])) {
+      if ([option.short, option.long].includes(args[i])) {
         // Remove the option flag itself and its value.
         args.splice(i, 2)
         // Only remove the first instance of the match - the second might be

--- a/cavy.js
+++ b/cavy.js
@@ -3,9 +3,9 @@ const program = require('commander');
 const init = require('./src/init');
 const runTests = require('./src/runTests');
 
-function getCommandParams(cmd) {
-  // Get array of Cavy options.
-  const options = cmd.options.map(option => option.short);
+function getCommandArgs(cmd) {
+  // Get array of Cavy options (short and long).
+  const options = cmd.options.map(option => [option.short, option.long]).flat();
   // Get array of all command line args.
   const allArgs = process.argv;
   const commandIndex = allArgs.indexOf(cmd.name());
@@ -20,9 +20,10 @@ function getCommandParams(cmd) {
 }
 
 function test(cmd) {
-  const args = getCommandParams(cmd);
+  const args = getCommandArgs(cmd);
   const commandName = cmd.name();
-  runTests(commandName, args);
+  const entryFile = cmd.file;
+  runTests(commandName, entryFile, args);
 }
 
 // Stop quitting unless we want to

--- a/cavy.js
+++ b/cavy.js
@@ -5,17 +5,23 @@ const runTests = require('./src/runTests');
 
 function getCommandArgs(cmd) {
   // Get array of Cavy options (short and long).
-  const options = cmd.options.map(option => [option.short, option.long]).flat();
+  const options = cmd.options.map(option => [option.short, option.long]);
   // Get array of all command line args.
   const allArgs = process.argv;
   const commandIndex = allArgs.indexOf(cmd.name());
   const args = allArgs.slice(commandIndex, allArgs.length)
-  // Remove Cavy options from other options, so that RN cli doesn't try to call
-  // them.
+  
+  // Remove Cavy options from other args so RN cli doesn't try to call them.
   options.forEach(option => {
-    args.forEach((arg, i) => { if (arg == option) args.splice(i, 2) });
+    for (var i = 0; i < args.length; i++) {
+      if (option.includes(args[i])) {
+        args.splice(i, 2)
+        // Only remove the first instance of the match - the second might be
+        // a valid RN CLI command option.
+        break;
+      };
+    }
   });
-
   return args;
 }
 

--- a/cavy.js
+++ b/cavy.js
@@ -10,11 +10,12 @@ function getCommandArgs(cmd) {
   const allArgs = process.argv;
   const commandIndex = allArgs.indexOf(cmd.name());
   const args = allArgs.slice(commandIndex, allArgs.length)
-  
+
   // Remove Cavy options from other args so RN cli doesn't try to call them.
   options.forEach(option => {
     for (var i = 0; i < args.length; i++) {
       if (option.includes(args[i])) {
+        // Remove the option flag itself and its value.
         args.splice(i, 2)
         // Only remove the first instance of the match - the second might be
         // a valid RN CLI command option.

--- a/src/init.js
+++ b/src/init.js
@@ -27,14 +27,14 @@ function setUpCavy(specFolderName) {
   // Exit if folder name invalid.
   if (folderNameInvalid(folderName)) {
     console.log("cavy: Folder name invalid. Please remove any reserved characters: <>:\"\/\\|?*");
-    process.exit(0);
+    process.exit(1);
   }
 
   // Exit if spec folder already exists.
   if (existsSync(folderName)) {
     console.log(`cavy: Looks like a ./${folderName} directory already exists for this project.`);
     console.log('cavy: To continue set up, re-run the command with an alternative test directory name: `cavy init <test-directory>`')
-    process.exit(0);
+    process.exit(1);
   }
 
   // Create a exampleTest.js file in the specified folder in the route of the
@@ -52,7 +52,7 @@ function setUpCavy(specFolderName) {
 
   // Exit
   console.log('cavy: Done!');
-  process.exit(1);
+  process.exit(0);
 }
 
 // Checks that you're inside a React Native project, and if so runs setUpCavy.
@@ -61,7 +61,7 @@ function init(specFolderName) {
     setUpCavy(specFolderName);
   } else {
     console.log("cavy: Make sure you're inside a React Native project and that you've run npm install.");
-    process.exit(0)
+    process.exit(1)
   }
 };
 

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -54,10 +54,19 @@ function getAdbPath() {
 // file: the file to boot the app from, supplied as a command option
 // args: any extra arguments the user would usually to pass to `react native run...`
 function runTests(command, file, args) {
+
   // Assume entry file is 'index.js' if user doesn't supply one.
   const entryFile = file || 'index.js';
+  const regex = /\.js$/;
+
+  // Check that the app entry file ends in .js before continuing.
+  if (!regex.test(entryFile)) {
+    console.log(`cavy: Please provide an app entry file that ends in .js`);
+    process.exit(1);
+  }
+
   // Assume that the user has set up Cavy in a corresponding .test.js file.
-  const testEntryFile = entryFile.replace(/\.js$/, '.test.js');
+  const testEntryFile = entryFile.replace(regex, '.test.js');
   const testEntryFileExists = existsSync(testEntryFile);
 
   // Warn the user and exit if no corresponding test file exists.

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -5,16 +5,45 @@ const server = require('../server');
 const { existsSync } = require('fs');
 const { spawn, execFileSync, execSync } = require('child_process');
 
+let switched = false;
+
+// Swap the user's test file into index.js to build the test app, and save a
+// temporary version of the entry file so we can put it back later.
+function switchEntryFile(entryFile, testEntryFile) {
+  console.log(`cavy: found an ${testEntryFile} entry point. Temporarily replacing ${entryFile} to run tests`);
+
+  const cmd = `mv ${entryFile} index.notest.js && mv ${testEntryFile} index.js`;
+  console.log(`cavy: running \`${cmd}\`...`);
+  execSync(cmd);
+
+  // Save that we did this, so we can undo it later.
+  switched = true;
+}
+
 // If file changes have been made, revert them.
-function _teardown() {
-  console.log('cavy: putting your index.js back');
-  const cmd = 'mv index.js index.test.js && mv index.notest.js index.js';
+function teardown(entryFile, testEntryFile) {
+  console.log(`cavy: putting your ${entryFile} back`);
+  const cmd = `mv index.js ${testEntryFile} && mv index.notest.js ${entryFile}`;
   console.log(`cavy: running \`${cmd}\`...`);
   execSync(cmd);
 }
 
-// Borrowed from react-native-cli
-function _getAdbPath() {
+function runAdbReverse() {
+  try {
+    // Run ADB reverse tcp:8082 tcp:8082 to allow reporting of test results
+    // from React Native. Borrowed from react-native-cli.
+    const adbPath = getAdbPath();
+    const adbArgs = ['reverse', 'tcp:8082', 'tcp:8082'];
+    console.log(`cavy: Running ${adbPath} ${adbArgs.join(' ')}`);
+    execFileSync(adbPath, adbArgs, {stdio: 'inherit'});
+  } catch(e) {
+    console.error(`Could not run adb reverse: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+// Borrowed from react-native-cli.
+function getAdbPath() {
   return process.env.ANDROID_HOME
     ? process.env.ANDROID_HOME + '/platform-tools/adb'
     : 'adb';
@@ -22,37 +51,29 @@ function _getAdbPath() {
 
 // Runs tests using the React Native CLI.
 // command: `cavy run-ios` or `cavy run-android`
+// file: the file to boot the app from, supplied as a command option
 // args: any extra arguments the user would usually to pass to `react native run...`
-function runTests(command, args) {
-  let testEntryPoint = false;
-  // Check whether the app has an index.test.js file...
-  if (existsSync('index.test.js')) {
-    // ... and if it does, use it to build the app - this is where Cavy config
-    // should be.
-    console.log('cavy: found an index.test.js entry point. Temporarily replacing index.js to run tests');
-
-    const cmd = 'mv index.js index.notest.js && mv index.test.js index.js';
-    console.log(`cavy: running \`${cmd}\`...`);
-    execSync(cmd);
-
-    // Save that we did this, so we can undo it later.
-    testEntryPoint = true;
+function runTests(command, file, args) {
+  // Assume entry file is 'index.js' if user doesn't supply one.
+  const entryFile = file || 'index.js';
+  // Assume that the user has set up Cavy in a corresponding .test.js file.
+  const testEntryFile = entryFile.replace(/\.js$/, '.test.js');
+  // Check whether the app has this test file and if so, swap it into index.js.
+  if (existsSync(testEntryFile)) {
+    switchEntryFile(entryFile, testEntryFile);
   }
-
   // Handle reverting any file changes made before exiting the process.
   process.on('exit', () => {
-    if (testEntryPoint) {
-      _teardown()
+    if (switched) {
+      teardown(entryFile, testEntryFile)
     };
   });
-
   // If the user interrupts the process (ctrl-c), revert any file changes before
   // exiting.
   process.on('SIGINT', () => {
     console.log('cavy: Received SIGINT, cleaning up');
     process.exit(1);
   });
-
   // Build the app, start the test server and wait for results.
   console.log(`cavy: running \`react-native ${command}\`...`);
 
@@ -68,17 +89,7 @@ function runTests(command, args) {
     // ... start test server, listening for test results to be posted.
     const app = server.listen(8082, () => {
       if (command == 'run-android') {
-        try {
-          // Run ADB reverse tcp:8082 tcp:8082 to allow reporting of test results
-          // from React Native. Borrowed from react-native-cli.
-          const adbPath = _getAdbPath();
-          const adbArgs = ['reverse', 'tcp:8082', 'tcp:8082'];
-          console.log(`cavy: Running ${adbPath} ${adbArgs.join(' ')}`);
-          execFileSync(adbPath, adbArgs, {stdio: 'inherit'});
-        } catch(e) {
-          console.error(`Could not run adb reverse: ${e.message}`);
-          process.exit(1);
-        }
+        runAdbReverse();
       }
       console.log(`cavy: listening on port 8082 for test results...`);
     });

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -10,10 +10,10 @@ let switched = false;
 // Swap the user's test file into index.js to build the test app, and save a
 // temporary version of the entry file so we can put it back later.
 function switchEntryFile(entryFile, testEntryFile) {
-  console.log(`cavy: found an ${testEntryFile} entry point. Temporarily replacing ${entryFile} to run tests`);
+  console.log(`cavy: Found an ${testEntryFile} entry point. Temporarily replacing ${entryFile} to run tests.`);
 
   const cmd = `mv ${entryFile} index.notest.js && mv ${testEntryFile} index.js`;
-  console.log(`cavy: running \`${cmd}\`...`);
+  console.log(`cavy: Running \`${cmd}\`...`);
   execSync(cmd);
 
   // Save that we did this, so we can undo it later.
@@ -22,9 +22,9 @@ function switchEntryFile(entryFile, testEntryFile) {
 
 // If file changes have been made, revert them.
 function teardown(entryFile, testEntryFile) {
-  console.log(`cavy: putting your ${entryFile} back`);
+  console.log(`cavy: Putting your ${entryFile} back.`);
   const cmd = `mv index.js ${testEntryFile} && mv index.notest.js ${entryFile}`;
-  console.log(`cavy: running \`${cmd}\`...`);
+  console.log(`cavy: Running \`${cmd}\`...`);
   execSync(cmd);
 }
 
@@ -37,7 +37,7 @@ function runAdbReverse() {
     console.log(`cavy: Running ${adbPath} ${adbArgs.join(' ')}`);
     execFileSync(adbPath, adbArgs, {stdio: 'inherit'});
   } catch(e) {
-    console.error(`Could not run adb reverse: ${e.message}`);
+    console.error(`Could not run adb reverse: ${e.message}.`);
     process.exit(1);
   }
 }
@@ -58,10 +58,19 @@ function runTests(command, file, args) {
   const entryFile = file || 'index.js';
   // Assume that the user has set up Cavy in a corresponding .test.js file.
   const testEntryFile = entryFile.replace(/\.js$/, '.test.js');
+  const testEntryFileExists = existsSync(testEntryFile);
+
+  // Warn the user and exit if no corresponding test file exists.
+  if (file && !testEntryFileExists) {
+    console.log(`cavy: Could not find test entry point named ${testEntryFile}.`);
+    process.exit(1);
+  }
+  
   // Check whether the app has this test file and if so, swap it into index.js.
-  if (existsSync(testEntryFile)) {
+  if (testEntryFileExists) {
     switchEntryFile(entryFile, testEntryFile);
   }
+
   // Handle reverting any file changes made before exiting the process.
   process.on('exit', () => {
     if (switched) {
@@ -75,7 +84,7 @@ function runTests(command, file, args) {
     process.exit(1);
   });
   // Build the app, start the test server and wait for results.
-  console.log(`cavy: running \`react-native ${command}\`...`);
+  console.log(`cavy: Running \`react-native ${command}\`...`);
 
   let rn = spawn('react-native', [command, ...args], { stdio: 'inherit' });
 
@@ -91,7 +100,7 @@ function runTests(command, file, args) {
       if (command == 'run-android') {
         runAdbReverse();
       }
-      console.log(`cavy: listening on port 8082 for test results...`);
+      console.log(`cavy: Listening on port 8082 for test results...`);
     });
   });
 }


### PR DESCRIPTION
**Includes**
- `cavy run-ios` and `cavy run-android` now have the -f (--file) option.
  - Pass in your app's main entry point and Cavy will assume that you have a corresponding `.test.js` version of this file, and boot the app from here.
- Exit with code 1 if the user provides an entry point but no corresponding test entry point exists.
- Tidying up of function names

**Notes**
- The option passed in is the main app entry point _not_ the test file. Is this confusing? Should we ask for the test file name and assume the main app entry point?
- Instead of inferring of the test entry point from the entry point provided by the user, we could get them to provide both of these filenames?

**Compatibility**
- New feature, backwards compatible, suggest minor version bump.