### PR TITLE
Fix Windows spawn issue

### DIFF
--- a/src/runTests.js
+++ b/src/runTests.js
@@ -95,7 +95,10 @@ function runTests(command, file, args) {
   // Build the app, start the test server and wait for results.
   console.log(`cavy: Running \`react-native ${command}\`...`);
 
-  let rn = spawn('react-native', [command, ...args], { stdio: 'inherit' });
+  let rn = spawn('react-native', [command, ...args], {
+    stdio: 'inherit',
+    shell: true
+  });
 
   // Wait for the app to build first...
   rn.on('close', (code) => {


### PR DESCRIPTION
Add `shell: true` parameter to fix issue https://github.com/pixielabs/cavy-cli/issues/3.
Also addresses issue on Cavy: https://github.com/pixielabs/cavy/issues/148.

@jalada - tested locally to ensure this has no effect when running on  iOS.