### PR TITLE
Developer options

### DIFF
--- a/cavy.js
+++ b/cavy.js
@@ -29,7 +29,8 @@ function test(cmd) {
   const commandName = cmd.name();
   const entryFile = cmd.file;
   const nobuild = cmd.nobuild;
-  runTests(commandName, entryFile, nobuild, args);
+  const dev = cmd.dev;
+  runTests(commandName, entryFile, nobuild, dev, args);
 }
 
 // Stop quitting unless we want to
@@ -52,6 +53,7 @@ program
     '-nb, --nobuild',
     'Just swap the index files and start the results server without building/running the app, for use with quick reload'
   )
+  .option('-d, --dev', 'Keep report server alive until manually killed')
   .allowUnknownOption()
   .action(cmd => test(cmd));
 
@@ -63,6 +65,7 @@ program
     '-nb, --nobuild',
     'Just swap the index files and start the results server without building/running the app, for use with quick reload'
   )
+  .option('-d, --dev', 'Keep report server alive until manually killed')
   .allowUnknownOption()
   .action(cmd => test(cmd));
 

--- a/cavy.js
+++ b/cavy.js
@@ -28,9 +28,9 @@ function test(cmd) {
   const args = getCommandArgs(cmd);
   const commandName = cmd.name();
   const entryFile = cmd.file;
-  const nobuild = cmd.nobuild;
+  const skipbuild = cmd.skipbuild;
   const dev = cmd.dev;
-  runTests(commandName, entryFile, nobuild, dev, args);
+  runTests(commandName, entryFile, skipbuild, dev, args);
 }
 
 // Stop quitting unless we want to
@@ -50,7 +50,7 @@ program
   .description('Run cavy spec on an ios simulator or device')
   .option('-f, --file <file>', 'App entry file')
   .option(
-    '-nb, --nobuild',
+    '-s, --skipbuild',
     'Just swap the index files and start the results server without building/running the app, for use with quick reload'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
@@ -62,7 +62,7 @@ program
   .description('Run cavy spec on an android simulator or device')
   .option('-f, --file <file>', 'App entry file')
   .option(
-    '-nb, --nobuild',
+    '-s, --skipbuild',
     'Just swap the index files and start the results server without building/running the app, for use with quick reload'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')

--- a/cavy.js
+++ b/cavy.js
@@ -28,7 +28,8 @@ function test(cmd) {
   const args = getCommandArgs(cmd);
   const commandName = cmd.name();
   const entryFile = cmd.file;
-  runTests(commandName, entryFile, args);
+  const nobuild = cmd.nobuild;
+  runTests(commandName, entryFile, nobuild, args);
 }
 
 // Stop quitting unless we want to
@@ -47,6 +48,10 @@ program
   .command('run-ios')
   .description('Run cavy spec on an ios simulator or device')
   .option('-f, --file <file>', 'App entry file')
+  .option(
+    '-nb, --nobuild',
+    'Just swap the index files and start the results server without building/running the app, for use with quick reload'
+  )
   .allowUnknownOption()
   .action(cmd => test(cmd));
 
@@ -54,6 +59,10 @@ program
   .command('run-android')
   .description('Run cavy spec on an android simulator or device')
   .option('-f, --file <file>', 'App entry file')
+  .option(
+    '-nb, --nobuild',
+    'Just swap the index files and start the results server without building/running the app, for use with quick reload'
+  )
   .allowUnknownOption()
   .action(cmd => test(cmd));
 

--- a/server.js
+++ b/server.js
@@ -50,6 +50,7 @@ server.post('/report', (req, res) => {
       process.exit(1);
     }
   }
+  console.log('--------------------');
 });
 
 // Public: GET route that can be used to check whether the server is listening

--- a/server.js
+++ b/server.js
@@ -40,11 +40,15 @@ server.post('/report', (req, res) => {
   if (!errorCount) {
     console.log(chalk.green(endMsg));
     res.send('ok');
-    process.exit(0);
+    if (!req.app.locals.dev) {
+      process.exit(0);
+    }
   } else {
     console.log(chalk.red(endMsg));
     res.send('failed');
-    process.exit(1);
+    if (!req.app.locals.dev) {
+      process.exit(1);
+    }
   }
 });
 

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -49,8 +49,9 @@ function getAdbPath() {
     : 'adb';
 }
 
-function runServer(command) {
+function runServer(command, dev) {
   // ... start test server, listening for test results to be posted.
+  server.locals.dev = dev;
   const app = server.listen(8082, () => {
     if (command == 'run-android') {
       runAdbReverse();
@@ -63,8 +64,9 @@ function runServer(command) {
 // command: `cavy run-ios` or `cavy run-android`
 // file: the file to boot the app from, supplied as a command option
 // nobuild: whether to skip the React Native build/run step
+// dev: whether to keep the server alive after tests finish
 // args: any extra arguments the user would usually to pass to `react native run...`
-function runTests(command, file, nobuild, args) {
+function runTests(command, file, nobuild, dev, args) {
 
   // Assume entry file is 'index.js' if user doesn't supply one.
   const entryFile = file || 'index.js';
@@ -105,7 +107,7 @@ function runTests(command, file, nobuild, args) {
   });
 
   if (nobuild) {
-    runServer(command);
+    runServer(command, dev);
   } else {
     // Build the app, start the test server and wait for results.
     console.log(`cavy: Running \`react-native ${command}\`...`);
@@ -122,7 +124,7 @@ function runTests(command, file, nobuild, args) {
       if (code) {
         return process.exit(code);
       }
-      runServer(command);
+      runServer(command, dev);
     });
   }
 }

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -49,11 +49,22 @@ function getAdbPath() {
     : 'adb';
 }
 
+function runServer(command) {
+  // ... start test server, listening for test results to be posted.
+  const app = server.listen(8082, () => {
+    if (command == 'run-android') {
+      runAdbReverse();
+    }
+    console.log(`cavy: Listening on port 8082 for test results...`);
+  });
+}
+
 // Runs tests using the React Native CLI.
 // command: `cavy run-ios` or `cavy run-android`
 // file: the file to boot the app from, supplied as a command option
+// nobuild: whether to skip the React Native build/run step
 // args: any extra arguments the user would usually to pass to `react native run...`
-function runTests(command, file, args) {
+function runTests(command, file, nobuild, args) {
 
   // Assume entry file is 'index.js' if user doesn't supply one.
   const entryFile = file || 'index.js';
@@ -92,29 +103,28 @@ function runTests(command, file, args) {
     console.log('cavy: Received SIGINT, cleaning up');
     process.exit(1);
   });
-  // Build the app, start the test server and wait for results.
-  console.log(`cavy: Running \`react-native ${command}\`...`);
 
-  let rn = spawn('react-native', [command, ...args], {
-    stdio: 'inherit',
-    shell: true
-  });
+  if (nobuild) {
+    runServer(command);
+  } else {
+    // Build the app, start the test server and wait for results.
+    console.log(`cavy: Running \`react-native ${command}\`...`);
 
-  // Wait for the app to build first...
-  rn.on('close', (code) => {
-    console.log(`cavy: react-native exited with code ${code}.`);
-    // ... quit if something went wrong.
-    if (code) {
-      return process.exit(code);
-    }
-    // ... start test server, listening for test results to be posted.
-    const app = server.listen(8082, () => {
-      if (command == 'run-android') {
-        runAdbReverse();
-      }
-      console.log(`cavy: Listening on port 8082 for test results...`);
+    let rn = spawn('react-native', [command, ...args], {
+      stdio: 'inherit',
+      shell: true
     });
-  });
+
+    // Wait for the app to build first...
+    rn.on('close', (code) => {
+      console.log(`cavy: react-native exited with code ${code}.`);
+      // ... quit if something went wrong.
+      if (code) {
+        return process.exit(code);
+      }
+      runServer(command);
+    });
+  }
 }
 
 module.exports = runTests;

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -49,8 +49,8 @@ function getAdbPath() {
     : 'adb';
 }
 
+// Start test server, listening for test results to be posted.
 function runServer(command, dev) {
-  // ... start test server, listening for test results to be posted.
   server.locals.dev = dev;
   const app = server.listen(8082, () => {
     if (command == 'run-android') {

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -63,10 +63,10 @@ function runServer(command, dev) {
 // Runs tests using the React Native CLI.
 // command: `cavy run-ios` or `cavy run-android`
 // file: the file to boot the app from, supplied as a command option
-// nobuild: whether to skip the React Native build/run step
+// skipbuild: whether to skip the React Native build/run step
 // dev: whether to keep the server alive after tests finish
 // args: any extra arguments the user would usually to pass to `react native run...`
-function runTests(command, file, nobuild, dev, args) {
+function runTests(command, file, skipbuild, dev, args) {
 
   // Assume entry file is 'index.js' if user doesn't supply one.
   const entryFile = file || 'index.js';
@@ -106,7 +106,7 @@ function runTests(command, file, nobuild, dev, args) {
     process.exit(1);
   });
 
-  if (nobuild) {
+  if (skipbuild) {
     runServer(command, dev);
   } else {
     // Build the app, start the test server and wait for results.


### PR DESCRIPTION
New command-line options for use when developing:
- `-s, --skipbuild`
  - Skips the step of building/running the app, so you can just reload an already-running debug build against the packager
- `-d, --dev`
  - Keeps the reporter service alive after receiving a report, so you can just _keep reloading_ an already-running debug build against the packager

The first was the main goal, as it was annoying to wait for a build when nothing changed, but the later seemed a logical next step while I was at it.

I know you can see test results in the debug console or the yellow overlay thingy, but the `cavy-cli` output is a little nicer IMO and it has the advantage of managing the index files, so you can use `-s -d` to just quickly put yourself in "Cavy mode" and then ctrl+C when you're done to revert things.

Totally open to feedback.