### PR TITLE
adding port option to CLI

### DIFF
--- a/cavy.js
+++ b/cavy.js
@@ -30,7 +30,8 @@ function test(cmd) {
   const entryFile = cmd.file;
   const skipbuild = cmd.skipbuild;
   const dev = cmd.dev;
-  runTests(commandName, entryFile, skipbuild, dev, args);
+  const port = cmd.port;
+  runTests(commandName, entryFile, skipbuild, dev, port, args);
 }
 
 // Stop quitting unless we want to
@@ -54,6 +55,7 @@ program
     'Swap the index files and start the report server without first building the app'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
+  .option('-p, --port <port>', 'Port to run Cavy on')
   .allowUnknownOption()
   .action(cmd => test(cmd));
 
@@ -66,6 +68,7 @@ program
     'Swap the index files and start the report server without first building the app'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
+  .option('-p, --port <port>', 'Port to run Cavy on')
   .allowUnknownOption()
   .action(cmd => test(cmd));
 


### PR DESCRIPTION
I found that I needed the ability to run Cavy on multiple ports at once so that I could run multiple emulators at once. This PR adds the functionality for `-p, --port <port>` to the CLI. If the option is not specified, the CLI will default back to the original 8082.

Let me know if there is anything I need to do to help get this PR through.