### PR TITLE
Timeout if RN app doesn't boot

### DIFF
--- a/cavy.js
+++ b/cavy.js
@@ -57,7 +57,7 @@ program
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
   .option(
-    '--boot-timeout <minutes>',
+    '-t, --boot-timeout <minutes>',
     'Set how long the CLI should wait for the RN app to boot '
     + '(is ignored if used with --skipbuild, defaults to 2 minutes)'
   )
@@ -75,7 +75,7 @@ program
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
   .option(
-    '--boot-timeout <minutes>',
+    '-t, --boot-timeout <minutes>',
     'Set how long the CLI should wait for the RN app to boot '
     + '(is ignored if used with --skipbuild, defaults to 2 minutes)'
   )

--- a/cavy.js
+++ b/cavy.js
@@ -31,12 +31,8 @@ function test(cmd) {
   const skipbuild = cmd.skipbuild;
   const outputAsXml = cmd.xml;
   const dev = cmd.dev;
-<<<<<<< HEAD
   const timeout = cmd.timeout;
-  runTests(commandName, entryFile, skipbuild, dev, timeout, args);
-=======
-  runTests(commandName, entryFile, skipbuild, dev, outputAsXml, args);
->>>>>>> master
+  runTests(commandName, entryFile, skipbuild, dev, outputAsXml, timeout, args);
 }
 
 // Stop quitting unless we want to
@@ -60,11 +56,8 @@ program
     'Swap the index files and start the report server without first building the app'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
-<<<<<<< HEAD
   .option('-t, --timeout <seconds>', 'Set timeout for Cavy cli in seconds (defaults to 20 seconds)')
-=======
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
->>>>>>> master
   .allowUnknownOption()
   .action(cmd => test(cmd));
 
@@ -77,11 +70,8 @@ program
     'Swap the index files and start the report server without first building the app'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
-<<<<<<< HEAD
   .option('-t, --timeout <seconds>', 'Set timeout for Cavy cli in seconds (defaults to 20 seconds)')
-=======
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
->>>>>>> master
   .allowUnknownOption()
   .action(cmd => test(cmd));
 

--- a/cavy.js
+++ b/cavy.js
@@ -57,8 +57,9 @@ program
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
   .option(
-    '-bt, --boot-timeout <seconds>',
+    '--boot-timeout <seconds>',
     'Set how long the CLI should wait for the RN app to boot (defaults to 20 seconds)'
+    + ''
   )
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
   .allowUnknownOption()
@@ -74,7 +75,7 @@ program
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
   .option(
-    '-bt, --boot-timeout <seconds>',
+    '--boot-timeout <seconds>',
     'Set how long the CLI should wait for the RN app to boot (defaults to 20 seconds)'
   )
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')

--- a/cavy.js
+++ b/cavy.js
@@ -57,9 +57,9 @@ program
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
   .option(
-    '--boot-timeout <seconds>',
-    'Set how long the CLI should wait for the RN app to boot (defaults to 20 seconds)'
-    + ''
+    '--boot-timeout <minutes>',
+    'Set how long the CLI should wait for the RN app to boot '
+    + '(is ignored if used with --skipbuild, defaults to 2 minutes)'
   )
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
   .allowUnknownOption()
@@ -75,8 +75,9 @@ program
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
   .option(
-    '--boot-timeout <seconds>',
-    'Set how long the CLI should wait for the RN app to boot (defaults to 20 seconds)'
+    '--boot-timeout <minutes>',
+    'Set how long the CLI should wait for the RN app to boot '
+    + '(is ignored if used with --skipbuild, defaults to 2 minutes)'
   )
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
   .allowUnknownOption()

--- a/cavy.js
+++ b/cavy.js
@@ -30,7 +30,8 @@ function test(cmd) {
   const entryFile = cmd.file;
   const skipbuild = cmd.skipbuild;
   const dev = cmd.dev;
-  runTests(commandName, entryFile, skipbuild, dev, args);
+  const timeout = cmd.timeout;
+  runTests(commandName, entryFile, skipbuild, dev, timeout, args);
 }
 
 // Stop quitting unless we want to
@@ -54,6 +55,7 @@ program
     'Swap the index files and start the report server without first building the app'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
+  .option('-t, --timeout <seconds>', 'Set timeout for Cavy cli in seconds (defaults to 20 seconds)')
   .allowUnknownOption()
   .action(cmd => test(cmd));
 
@@ -66,6 +68,7 @@ program
     'Swap the index files and start the report server without first building the app'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
+  .option('-t, --timeout <seconds>', 'Set timeout for Cavy cli in seconds (defaults to 20 seconds)')
   .allowUnknownOption()
   .action(cmd => test(cmd));
 

--- a/cavy.js
+++ b/cavy.js
@@ -59,7 +59,7 @@ program
   .option(
     '-t, --boot-timeout <minutes>',
     'Set how long the CLI should wait for the RN app to boot '
-    + '(is ignored if used with --skipbuild, defaults to 2 minutes)'
+    + '(is ignored if used with --skipbuild, defaults to 2 minutes, requires Cavy 4.0.0)'
   )
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
   .allowUnknownOption()
@@ -77,7 +77,7 @@ program
   .option(
     '-t, --boot-timeout <minutes>',
     'Set how long the CLI should wait for the RN app to boot '
-    + '(is ignored if used with --skipbuild, defaults to 2 minutes)'
+    + '(is ignored if used with --skipbuild, defaults to 2 minutes, requires Cavy 4.0.0)'
   )
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
   .allowUnknownOption()

--- a/cavy.js
+++ b/cavy.js
@@ -31,8 +31,8 @@ function test(cmd) {
   const skipbuild = cmd.skipbuild;
   const outputAsXml = cmd.xml;
   const dev = cmd.dev;
-  const timeout = cmd.timeout;
-  runTests(commandName, entryFile, skipbuild, dev, outputAsXml, timeout, args);
+  const bootTimeout = cmd.bootTimeout;
+  runTests(commandName, entryFile, skipbuild, dev, outputAsXml, bootTimeout, args);
 }
 
 // Stop quitting unless we want to
@@ -56,7 +56,10 @@ program
     'Swap the index files and start the report server without first building the app'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
-  .option('-t, --timeout <seconds>', 'Set timeout for Cavy cli in seconds (defaults to 20 seconds)')
+  .option(
+    '-bt, --boot-timeout <seconds>',
+    'Set how long the CLI should wait for the RN app to boot (defaults to 20 seconds)'
+  )
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
   .allowUnknownOption()
   .action(cmd => test(cmd));
@@ -70,7 +73,10 @@ program
     'Swap the index files and start the report server without first building the app'
   )
   .option('-d, --dev', 'Keep report server alive until manually killed')
-  .option('-t, --timeout <seconds>', 'Set timeout for Cavy cli in seconds (defaults to 20 seconds)')
+  .option(
+    '-bt, --boot-timeout <seconds>',
+    'Set how long the CLI should wait for the RN app to boot (defaults to 20 seconds)'
+  )
   .option('--xml', 'Write out test results to cavy_results.xml (requires Cavy 3.3.0)')
   .allowUnknownOption()
   .action(cmd => test(cmd));

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "commander": "^2.12.2",
-    "express": "^4.16.2"
+    "ws": "^7.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -12,11 +12,14 @@ server.locals = { appBooted: false};
 // Initialize a WebSocket Server instance
 const wss = new WebSocket.Server({server});
 
-// Setup the wanted behaviour for specific socket events
+// When the web socket server receives a connection request, we configure
+// the desired behaviour for the socket.
 wss.on('connection', socket => {
+  // If we receive a 'message' event from the Cavy-side socket,
+  // we want to pass the message into processReport().
   socket.on('message', message => {
-    const resultsJSON = JSON.parse(message);
-    processReport(resultsJSON);
+    const resultsJson = JSON.parse(message);
+    processReport(resultsJson);
   });
 
   // Now we have made a connection with Cavy, we know the app has booted.
@@ -35,8 +38,8 @@ function countString(count, str) {
 // Internal: Accepts a json report object, console logs the results
 // and quits the process with either exit code 1 or 0 depending on whether any
 // tests failed.
-function processReport(resultsJSON) {
-  const { results, fullResults, errorCount, duration } = resultsJSON;
+function processReport(resultsJson) {
+  const { results, fullResults, errorCount, duration } = resultsJson;
 
   results.forEach((result, index) => {
     message = `${index + 1}) ${result['message']}`;

--- a/server.js
+++ b/server.js
@@ -18,8 +18,8 @@ const wss = new WebSocket.Server({server});
 // When the web socket server receives a connection request, we configure
 // the desired behaviour for the socket.
 wss.on('connection', socket => {
-  // If we receive a 'message' event from the Cavy-side socket,
-  // we want to pass the message into processReport().
+  // If we receive a 'message' from the Cavy-side socket, we parse the payload
+  // and direct the processing behaviour based on the json.event
   socket.on('message', message => {
     const json = JSON.parse(message);
 

--- a/server.js
+++ b/server.js
@@ -65,6 +65,9 @@ function logTestResult(testResultJson) {
 function shutDownServer(reportJson) {
   const { results, fullResults, errorCount, duration } = reportJson;
 
+  // Set the testCount to zero at the end of the test suite.
+  server.locals.testCount = 0;
+
   console.log(`Finished in ${duration} seconds`);
   const endMsg = `${countString(results.length, 'example')}, ${countString(errorCount, 'failure')}`;
 

--- a/server.js
+++ b/server.js
@@ -68,7 +68,9 @@ function logTestResult(testResultJson) {
 function shutDownServer(reportJson) {
   const { results, fullResults, errorCount, duration } = reportJson;
 
-  // Set the testCount to zero at the end of the test suite.
+  // Set the testCount to zero at the end of the test suite. This ensures
+  // the test numbering is reset in the case where `--dev` option is
+  // supplied and we don't restart the server.
   server.locals.testCount = 0;
 
   console.log(`Finished in ${duration} seconds`);

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ wss.on('connection', socket => {
   socket.on('message', message => {
     const json = JSON.parse(message);
 
-    switch(json.route) {
+    switch(json.event) {
       case 'singleResult':
         logTestResult(json.data);
         break;

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ wss.on('connection', socket => {
         logTestResult(json.data);
         break;
       case 'testingComplete':
-        shutDownServer(json.data);
+        finishTesting(json.data);
         break;
     }
   });
@@ -65,7 +65,7 @@ function logTestResult(testResultJson) {
 // Internal: Accepts a json report object, console.logs the overall result of
 // the test suite and quits the process with either exit code 1 or 0 depending
 // on whether any tests failed.
-function shutDownServer(reportJson) {
+function finishTesting(reportJson) {
   const { results, fullResults, errorCount, duration } = reportJson;
 
   // Set the testCount to zero at the end of the test suite. This ensures

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -6,7 +6,7 @@ const { existsSync } = require('fs');
 const { spawn, execFileSync, execSync } = require('child_process');
 
 // Twenty seconds in milliseconds
-const TWENTY_SECONDS = 20000
+const TWENTY_SECONDS = 20000;
 
 let switched = false;
 

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -5,6 +5,9 @@ const server = require('../server');
 const { existsSync } = require('fs');
 const { spawn, execFileSync, execSync } = require('child_process');
 
+// Twenty seconds in milliseconds
+const TWENTY_SECONDS = 20000
+
 let switched = false;
 
 // Swap the user's test file into index.js to build the test app, and save a
@@ -60,8 +63,10 @@ function runServer(command, dev, outputAsXml, bootTimeout) {
     console.log(`cavy: Listening on port 8082 for test results...`);
     setTimeout(() => {
       if (!server.locals.appBooted) {
-        console.log("No response from Cavy.");
-        console.log("Terminating processes.");
+        // Convert bootTimeout from milliseconds to seconds.
+        const timeoutInSecs = bootTimeout/1000;
+        console.log(`No response from Cavy within ${timeoutInSecs} seconds.`);
+        console.log('Terminating processes.');
         process.exit(1);
       }
     }, bootTimeout);
@@ -117,7 +122,7 @@ function runTests(command, file, skipbuild, dev, outputAsXml, bootTimeout, args)
   });
 
   // Convert bootTimeout to milliseconds, default to 20 seconds
-  const timeout = (bootTimeout * 1000) || 20000
+  const timeout = (bootTimeout * 1000) || TWENTY_SECONDS
 
   if (skipbuild) {
     runServer(command, dev, outputAsXml, timeout);

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -50,7 +50,7 @@ function getAdbPath() {
 }
 
 // Start test server, listening for test results to be posted.
-function runServer(command, dev, outputAsXml, timeout) {
+function runServer(command, dev, outputAsXml, bootTimeout) {
   server.locals.dev = dev;
   server.locals.outputAsXml = outputAsXml;
   server.listen(8082, () => {
@@ -64,7 +64,7 @@ function runServer(command, dev, outputAsXml, timeout) {
         console.log("Terminating processes.");
         process.exit(1);
       }
-    }, timeout);
+    }, bootTimeout);
   });
 }
 
@@ -74,8 +74,9 @@ function runServer(command, dev, outputAsXml, timeout) {
 // skipbuild: whether to skip the React Native build/run step
 // dev: whether to keep the server alive after tests finish
 // outputAsXml: whether to write and save the results to XML file
+// bootTimeout: how long the CLI should wait for the RN app to boot.
 // args: any extra arguments the user would usually to pass to `react native run...`
-function runTests(command, file, skipbuild, dev, outputAsXml, timeout, args) {
+function runTests(command, file, skipbuild, dev, outputAsXml, bootTimeout, args) {
 
   // Assume entry file is 'index.js' if user doesn't supply one.
   const entryFile = file || 'index.js';
@@ -115,11 +116,11 @@ function runTests(command, file, skipbuild, dev, outputAsXml, timeout, args) {
     process.exit(1);
   });
 
-  // Convert timeout to milliseconds, default to 20 seconds
-  const cliTimeout = (timeout * 1000) || 20000
+  // Convert bootTimeout to milliseconds, default to 20 seconds
+  const timeout = (bootTimeout * 1000) || 20000
 
   if (skipbuild) {
-    runServer(command, dev, outputAsXml, cliTimeout);
+    runServer(command, dev, outputAsXml, timeout);
   } else {
     // Build the app, start the test server and wait for results.
     console.log(`cavy: Running \`react-native ${command}\`...`);
@@ -136,7 +137,7 @@ function runTests(command, file, skipbuild, dev, outputAsXml, timeout, args) {
       if (code) {
         return process.exit(code);
       }
-      runServer(command, dev, outputAsXml, cliTimeout);
+      runServer(command, dev, outputAsXml, timeout);
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,41 +2,11 @@
 # yarn lockfile v1
 
 
-accepts@~1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
-  dependencies:
-    mime-types "~2.1.16"
-    negotiator "0.6.1"
-
 ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
-
-array-flatten@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
-
-body-parser@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
-  dependencies:
-    bytes "3.0.0"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "~1.1.1"
-    http-errors "~1.6.2"
-    iconv-lite "0.4.19"
-    on-finished "~2.3.0"
-    qs "6.5.1"
-    raw-body "2.3.2"
-    type-is "~1.6.15"
-
-bytes@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
 chalk@^2.3.0:
   version "2.3.0"
@@ -60,254 +30,13 @@ commander@^2.12.2:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
-content-disposition@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
-
-content-type@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-
-cookie-signature@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
-
-cookie@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-
-debug@2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  dependencies:
-    ms "2.0.0"
-
-depd@1.1.1, depd@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
-
-destroy@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
-
-ee-first@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
-
-encodeurl@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
-
-escape-html@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-etag@~1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
-
-express@^4.16.2:
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
-  dependencies:
-    accepts "~1.3.4"
-    array-flatten "1.1.1"
-    body-parser "1.18.2"
-    content-disposition "0.5.2"
-    content-type "~1.0.4"
-    cookie "0.3.1"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "~1.1.1"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.1.0"
-    fresh "0.5.2"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "~2.3.0"
-    parseurl "~1.3.2"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.2"
-    qs "6.5.1"
-    range-parser "~1.2.0"
-    safe-buffer "5.1.1"
-    send "0.16.1"
-    serve-static "1.13.1"
-    setprototypeof "1.1.0"
-    statuses "~1.3.1"
-    type-is "~1.6.15"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
-
-finalhandler@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
-  dependencies:
-    debug "2.6.9"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    on-finished "~2.3.0"
-    parseurl "~1.3.2"
-    statuses "~1.3.1"
-    unpipe "~1.0.0"
-
-forwarded@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
-
-fresh@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
-
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
-
-http-errors@1.6.2, http-errors@~1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
-  dependencies:
-    depd "1.1.1"
-    inherits "2.0.3"
-    setprototypeof "1.0.3"
-    statuses ">= 1.3.1 < 2"
-
-iconv-lite@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-
-inherits@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-
-ipaddr.js@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz#d4b505bde9946987ccf0fc58d9010ff9607e3fa0"
-
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-
-merge-descriptors@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-
-methods@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
-
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
-
-mime-types@~2.1.15, mime-types@~2.1.16:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
-  dependencies:
-    mime-db "~1.30.0"
-
-mime@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-
-negotiator@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
-
-on-finished@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
-  dependencies:
-    ee-first "1.1.1"
-
-parseurl@~1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
-
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-
-proxy-addr@~2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.2.tgz#6571504f47bb988ec8180253f85dd7e14952bdec"
-  dependencies:
-    forwarded "~0.1.2"
-    ipaddr.js "1.5.2"
-
-qs@6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
-range-parser@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
-
-raw-body@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
-  dependencies:
-    bytes "3.0.0"
-    http-errors "1.6.2"
-    iconv-lite "0.4.19"
-    unpipe "1.0.0"
-
-safe-buffer@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-
-send@0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.16.1.tgz#a70e1ca21d1382c11d0d9f6231deb281080d7ab3"
-  dependencies:
-    debug "2.6.9"
-    depd "~1.1.1"
-    destroy "~1.0.4"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "~1.6.2"
-    mime "1.4.1"
-    ms "2.0.0"
-    on-finished "~2.3.0"
-    range-parser "~1.2.0"
-    statuses "~1.3.1"
-
-serve-static@1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.1.tgz#4c57d53404a761d8f2e7c1e8a18a47dbf278a719"
-  dependencies:
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    parseurl "~1.3.2"
-    send "0.16.1"
-
-setprototypeof@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
-
-setprototypeof@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
-
-"statuses@>= 1.3.1 < 2":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
-
-statuses@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
 supports-color@^4.0.0:
   version "4.5.0"
@@ -315,21 +44,7 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-type-is@~1.6.15:
-  version "1.6.15"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.15"
-
-unpipe@1.0.0, unpipe@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
-
-utils-merge@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
-
-vary@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+ws@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
+  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==


### PR DESCRIPTION
### 🚨 Before Merging
Update the `--boot-timeout` flag description with the required version numbers for Cavy and Cavy Cli. --> https://github.com/pixielabs/cavy-cli/pull/29#discussion_r426549914

### Includes
- add --boot-timeout flag to the cli.
- if the React Native application does not boot within stated time, shut down cavy cli.
- receive communications from Cavy via a web socket.

### Testing
To test you need use this [branch](https://github.com/pixielabs/cavy/tree/timeout-if-app-doesnt-boot) of Cavy.
See this [PR](https://github.com/pixielabs/cavy/pull/177).
