### PR TITLE
Receive in-progress test results from Cavy

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,8 +18,8 @@ const wss = new WebSocket.Server({server});
 // When the web socket server receives a connection request, we configure
 // the desired behaviour for the socket.
 wss.on('connection', socket => {
-  // If we receive a 'message' event from the Cavy-side socket,
-  // we want to pass the message into processReport().
+  // If we receive a 'message' from the Cavy-side socket, we parse the payload
+  // and direct the processing behaviour based on the json.event
   socket.on('message', message => {
     const json = JSON.parse(message);
 

--- a/server.js
+++ b/server.js
@@ -65,6 +65,9 @@ function logTestResult(testResultJson) {
 function shutDownServer(reportJson) {
   const { results, fullResults, errorCount, duration } = reportJson;
 
+  // Set the testCount to zero at the end of the test suite.
+  server.locals.testCount = 0;
+
   console.log(`Finished in ${duration} seconds`);
   const endMsg = `${countString(results.length, 'example')}, ${countString(errorCount, 'failure')}`;
 

--- a/server.js
+++ b/server.js
@@ -68,7 +68,9 @@ function logTestResult(testResultJson) {
 function shutDownServer(reportJson) {
   const { results, fullResults, errorCount, duration } = reportJson;
 
-  // Set the testCount to zero at the end of the test suite.
+  // Set the testCount to zero at the end of the test suite. This ensures
+  // the test numbering is reset in the case where `--dev` option is
+  // supplied and we don't restart the server.
   server.locals.testCount = 0;
 
   console.log(`Finished in ${duration} seconds`);

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ wss.on('connection', socket => {
   socket.on('message', message => {
     const json = JSON.parse(message);
 
-    switch(json.route) {
+    switch(json.event) {
       case 'singleResult':
         logTestResult(json.data);
         break;

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ wss.on('connection', socket => {
         logTestResult(json.data);
         break;
       case 'testingComplete':
-        shutDownServer(json.data);
+        finishTesting(json.data);
         break;
     }
   });
@@ -65,7 +65,7 @@ function logTestResult(testResultJson) {
 // Internal: Accepts a json report object, console.logs the overall result of
 // the test suite and quits the process with either exit code 1 or 0 depending
 // on whether any tests failed.
-function shutDownServer(reportJson) {
+function finishTesting(reportJson) {
   const { results, fullResults, errorCount, duration } = reportJson;
 
   // Set the testCount to zero at the end of the test suite. This ensures


### PR DESCRIPTION
### Includes
- the cli server can handle two message types, `singleResult` and `testingComplete`.
    - For `singleResult` the cli logs the test message.
    - For `testingComplete` the cli server winds down.

### Testing
To test you need use [this](send-in-progress-test-results) branch of Cavy.
See this [PR](https://github.com/pixielabs/cavy/pull/178).