### PR TITLE
[BUG] Escape spaces in all args

### DIFF
--- a/cavy.js
+++ b/cavy.js
@@ -21,7 +21,9 @@ function getCommandArgs(cmd) {
       };
     }
   });
-  return args;
+
+  // Escape spaces.
+  return args.map(a => a.replace(/ /g, '\\ '));
 }
 
 function test(cmd) {


### PR DESCRIPTION
[Roadmap ticket](https://www.pivotaltracker.com/story/show/172888083)
Issue: https://github.com/pixielabs/cavy-cli/issues/31

Fixes issue with passing through react-native-cli command line arguments like `cavy run-ios --simulator="iPhone 8"`, which gives the error `Could not find "iPhone" simulator`.

This is not tested on windows, and I'm slightly worried about the differing ways arguments may be handled. We already had to add `shell: true` when we spawn the `react-native` command for windows.

@jalada - last time you were best placed to test on windows, would you be able to get to test? 🙏 