### PR TITLE
Change exit code for failing tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -81,7 +81,9 @@ function finishTesting(reportJson) {
     constructXML(fullResults);
   }
 
-  // If all tests pass, exit with code 0, else code 1
+  // If all tests pass, exit with code 0, else code 42.
+  // Code 42 chosen at random so that a test failure can be distinuguished from
+  // a build failure (in which case the React Native CLI would exit with code 1).
   if (!errorCount) {
     console.log(chalk.green(endMsg));
     if (!server.locals.dev) {
@@ -90,7 +92,7 @@ function finishTesting(reportJson) {
   } else {
     console.log(chalk.red(endMsg));
     if (!server.locals.dev) {
-      process.exit(1);
+      process.exit(42);
     }
   }
   console.log('--------------------');


### PR DESCRIPTION
**What does it do?**
- Changes Cavy's exit code when tests fail from 1 to 42.

**Why?**
- As per issue https://github.com/pixielabs/cavy-cli/issues/36 , currently we don't distinguish between a react native build failure and a cavy failure. This makes it easier to detect.

**Release notes**
- Propose this as a minor release 2.1.0 and there is no changes to make to cavy itself. @jalada do you agree? 