### PR TITLE
Remove redundant "details" element from XML report

### DIFF
--- a/src/junitFormatter.js
+++ b/src/junitFormatter.js
@@ -11,7 +11,6 @@ function formattedTestError(test) {
       // At the moment, Cavy doesn't have different failure types.
       type: 'cavy test failure'
     },
-    _: test.message
   }
 }
 


### PR DESCRIPTION
It only contained the test name and failure message, both of which are already reported elsewhere in the XML.

Based on discussion in https://github.com/pixielabs/cavy-cli/issues/24#issuecomment-679429883

As I said in that conversation, I'm only testing with TeamCity, so I'd be interested if there are other parsers of these reports where this would be a problem.