### PR TITLE
Update to use npx as per react-native docs

### DIFF
--- a/src/runTests.js
+++ b/src/runTests.js
@@ -137,9 +137,9 @@ function runTests(command, file, skipbuild, dev, outputAsXml, bootTimeout, args)
     runServer({ command, dev, outputAsXml, skipbuild, bootTimeout });
   } else {
     // Build the app, start the test server and wait for results.
-    console.log(`cavy: Running \`react-native ${command}\`...`);
+    console.log(`cavy: Running \`npx react-native ${command}\`...`);
 
-    let rn = spawn('react-native', [command, ...args], {
+    let rn = spawn('npx', ['react-native', command, ...args], {
       stdio: 'inherit',
       shell: true
     });


### PR DESCRIPTION
`react-native-cli` global package no longer supported.

Probably a breaking change, for safety's sake.