### PR TITLE
Match the printed version to the actual one

### DIFF
--- a/cavy.js
+++ b/cavy.js
@@ -40,7 +40,7 @@ function test(cmd) {
 // Stop quitting unless we want to
 process.stdin.resume();
 
-program.version('3.0.0');
+program.version('3.0.1');
 
 program
   .command('init [specFolderName]')

--- a/cavy.js
+++ b/cavy.js
@@ -40,7 +40,7 @@ function test(cmd) {
 // Stop quitting unless we want to
 process.stdin.resume();
 
-program.version('2.2.0');
+program.version('3.0.0');
 
 program
   .command('init [specFolderName]')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavy-cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A command line interface for Cavy, a React Native integration testing framework",
   "bin": {
     "cavy": "./cavy.js"


### PR DESCRIPTION
The version in package.json is 3.0.0, match it in the printed version (should I change both to 3.0.1 so you can publish the fix?)